### PR TITLE
Updates to carnivore.json

### DIFF
--- a/items/comestibles/carnivore.json
+++ b/items/comestibles/carnivore.json
@@ -144,10 +144,166 @@
 	"freezing_point": -1000
   },
   {
-    "id": "human_smoked",
+    "id": "mutant_meat",
     "type": "COMESTIBLE",
-    "name": "smoked sucker",
-    "copy-from": "human_smoked",
+    "name": "chunk of mutant meat",
+    "name_plural": "chunks of mutant meat",
+    "copy-from": "mutant_meat",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_meat_scrap",
+    "type": "COMESTIBLE",
+    "name": "scrap of mutant meat",
+    "name_plural": "scraps of mutant meat",
+    "copy-from": "mutant_meat_scrap",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_human_flesh",
+    "type": "COMESTIBLE",
+    "name": "mutant humanoid meat",
+    "copy-from": "mutant_human_flesh",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_human_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked cretin",
+    "copy-from": "mutant_human_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_meat_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked mutant meat",
+    "copy-from": "mutant_meat_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_meat_scrap_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked scrap of mutant meat",
+    "name_plural": "cooked scraps of mutant meat",
+    "copy-from": "mutant_meat_scrap_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "lung",
+    "type": "COMESTIBLE",
+    "name": "piece of raw lung",
+    "name_plural": "pieces of raw lung",
+    "copy-from": "lung",
+	"freezing_point": -1000
+  },
+  {
+    "id": "lung_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked piece of lung",
+    "name_plural": "cooked pieces of lung",
+    "copy-from": "lung_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "liver",
+    "type": "COMESTIBLE",
+    "name": "raw liver",
+    "copy-from": "liver",
+	"freezing_point": -1000
+  },
+  {
+    "id": "liver_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked liver",
+    "copy-from": "liver_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "brain",
+    "type": "COMESTIBLE",
+    "name": "raw brains",
+    "name_plural": "raw brains",
+    "copy-from": "brain",
+	"freezing_point": -1000
+  },
+  {
+    "id": "brain_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked brains",
+    "name_plural": "cooked brains",
+    "copy-from": "brain_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "kidney",
+    "type": "COMESTIBLE",
+    "name": "raw kidney",
+    "copy-from": "kidney",
+	"freezing_point": -1000
+  },
+  {
+    "id": "kidney_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked kidney",
+    "copy-from": "kidney_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "sweetbread",
+    "type": "COMESTIBLE",
+    "name": "raw sweetbread",
+    "copy-from": "sweetbread",
+	"freezing_point": -1000
+  },
+  {
+    "id": "sweetbread_cooked",
+    "type": "COMESTIBLE",
+    "name": "cooked sweetbread",
+    "copy-from": "sweetbread_cooked",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_fat",
+    "type": "COMESTIBLE",
+    "name": "chunk of mutant fat",
+    "name_plural": "chunks of mutant fat",
+    "copy-from": "mutant_fat",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_tallow",
+    "type": "COMESTIBLE",
+    "name": "mutant tallow",
+    "copy-from": "mutant_tallow",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_lard",
+    "type": "COMESTIBLE",
+    "name": "mutant lard",
+    "copy-from": "mutant_lard",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_human_fat",
+    "type": "COMESTIBLE",
+    "name": "chunk of mutant humanoid fat",
+    "name_plural": "chunks of mutant humanoid fat",
+    "copy-from": "mutant_human_fat",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_human_lard",
+    "type": "COMESTIBLE",
+    "name": "mutant humanoid lard",
+    "copy-from": "mutant_human_lard",
+	"freezing_point": -1000
+  },
+  {
+    "id": "mutant_human_lard",
+    "type": "COMESTIBLE",
+    "name": "mutant humanoid lard",
+    "copy-from": "mutant_human_lard",
 	"freezing_point": -1000
   }
 ]


### PR DESCRIPTION
While testing it after last update, it was reporting a skippable load error that wasn't as easy to pinpoint as the previous errors. Since it took me a fair while to find the cause, I ended up deciding to say "just fork it" and PR the fix once I finally found the cause. Along the way I ended up adding updates to a few items that've been added to vanilla.

* Removed a single remaining dummied-out item that was inexplicably causing a "type not found" error with no indication of the problem file. Dunno why, when all the other dummied out cannibal food gave errors that made the cause easier to find.
* Also added `copy-from`s for most of the carnivore items that've since been added. Weird because they SHOULD be getting freeze points from your edits to the ones they copy from, but for some crazy reason only a few of the offending items are doing that properly.

No doubt there are more to be added (meat_dishes.json is a likely source for a majority of them), but it's a start.